### PR TITLE
feat: introduce exponential backoff for AWS API to avoid Rate Exceede…

### DIFF
--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -77,9 +77,10 @@ if (timeout) {
 PromiseQueue.configure(Promise);
 const requestQueue = new PromiseQueue(2, Infinity);
 
+const MAX_BACKOFF = 20000; // Maximum backoff time in milliseconds (20 seconds)
 const MAX_RETRIES = (() => {
   const userValue = Number(process.env.SLS_AWS_REQUEST_MAX_RETRIES);
-  return userValue >= 0 ? userValue : 4;
+  return userValue >= 0 ? userValue : 5;
 })();
 
 const accelerationCompatibleS3Methods = new Set(['upload', 'putObject']);
@@ -139,7 +140,6 @@ async function awsRequest(service, method, ...args) {
     ensureString(service, { name: 'service' });
     service = { name: service };
   }
-  const BASE_BACKOFF = 5000;
   const persistentRequest = async (f, numTry = 0) => {
     try {
       return await f();
@@ -155,9 +155,11 @@ async function awsRequest(service, method, ...args) {
           providerError.statusCode === 429)
       ) {
         const nextTryNum = numTry + 1;
-        const jitter = Math.random() * 3000 - 1000;
-        // backoff is between 4 and 7 seconds
-        const backOff = BASE_BACKOFF + jitter;
+
+        // Generate a random base within the range of 0 <= backOffBase <= 1
+        const backOffBase = Math.random();
+        // Exponential backoff calculation with cap at MAX_BACKOFF
+        const backOff = Math.min(backOffBase * Math.pow(2, nextTryNum) * 1000, MAX_BACKOFF);
         log.info(
           [
             `Recoverable error occurred (${e.message}), sleeping for ~${Math.round(


### PR DESCRIPTION
Introduce Exponential Back Off strategy for AWS calls as recommended by [AWS guidelines](https://repost.aws/knowledge-center/cloudformation-rate-exceeded-error). 

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #12396 
